### PR TITLE
Changing Universalical to updated helper function

### DIFF
--- a/apps/universalical/universal_ical.star
+++ b/apps/universalical/universal_ical.star
@@ -323,6 +323,8 @@ DEFAULT_TRUNCATE_EVENT_SUMMARY = True
 DEFAULT_SHOW_FULL_NAMES = True
 DEFAULT_TIMEZONE = "America/New_York"
 FRAME_DELAY = 500
-LAMBDA_URL = "https://xmd10xd284.execute-api.us-east-1.amazonaws.com/ics-next-event"
+LAMBDA_URL = "https://6bfnhr9vy7.execute-api.us-east-1.amazonaws.com/ics-next-event"
+#this is the original AWS Lambda URL that is hosting the helper function
+#LAMBDA_URL = "https://xmd10xd284.execute-api.us-east-1.amazonaws.com/ics-next-event"
 CALENDAR_ICON = base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAkAAAALCAYAAACtWacbAAAAAXNSR0IArs4c6QAAAE9JREFUKFNjZGBgYJgzZ87/lJQURlw0I0xRYEMHw/qGCgZ0GqSZ8a2Myv8aX1eGls27GXDRYEUg0/ABxv///xOn6OjRowzW1tYMuOghaxIAD/ltSOskB+YAAAAASUVORK5CYII=")
 DEFAULT_ICS_URL = "https://www.phpclasses.org/browse/download/1/file/63438/name/example.ics"


### PR DESCRIPTION
Changed the AWS Helper function to point to an updated parser which can be found here: https://github.com/JeffLac/ics-calendar-tidbyt-lambda
