### PR TITLE
Adding capabilities and fixing bugs in Universal iCal

### DIFF
--- a/apps/universalical/universal_ical.star
+++ b/apps/universalical/universal_ical.star
@@ -14,9 +14,7 @@ def main(config):
         config.get("$tz", DEFAULT_TIMEZONE),
     )
 
-
-    show_expanded_time_window = config.str("show_expanded_time_window", DEFAULT_SHOW_EXPANDED_TIME_WINDOW)
-
+    show_expanded_time_window = config.bool("show_expanded_time_window", DEFAULT_SHOW_EXPANDED_TIME_WINDOW)
 
     ics_url = config.str("ics_url", DEFAULT_ICS_URL)
     if (ics_url == None):
@@ -78,6 +76,7 @@ def get_expanded_time_text_copy(event, now, eventStart):
 
 def get_calendar_text_copy(event, now, eventStart, show_expanded_time_window):
     DEFAULT = eventStart.format("at 3:04 PM")
+
     if not event["detail"]["isToday"] and not show_expanded_time_window:
         return DONE_TEXT
     elif event["detail"] and show_expanded_time_window:
@@ -97,8 +96,6 @@ def get_calendar_render_data(now, usersTz, event, show_expanded_time_window):
     if not event:
         baseObject["hasEvent"] = False
         return baseObject
-
-    #print (show_expanded_time_window)
     
     shouldRenderSummary = event["detail"]["isToday"] or show_expanded_time_window
     if not shouldRenderSummary:

--- a/apps/universalical/universal_ical.star
+++ b/apps/universalical/universal_ical.star
@@ -33,7 +33,8 @@ def main(config):
  
     if not event:
         return build_calendar_frame(now, timezone, event, show_expanded_time_window, show_full_names)
-    elif event["detail"]["inProgress"]:
+    #if there's an event inProgress, and it's not an All Day event, show the event
+    elif event["detail"]["inProgress"] and not event["detail"]["isAllDay"]:
         return build_event_frame(event)
     elif event["detail"]:
         return build_calendar_frame(now, timezone, event, show_expanded_time_window, show_full_names)
@@ -42,7 +43,9 @@ def main(config):
 
 def get_calendar_text_color(event):
     DEFAULT = "#ff83f3"
-    if event["detail"]["minutesUntilStart"] <= 5:
+    if event["detail"]["isAllDay"]:
+        return DEFAULT
+    elif event["detail"]["minutesUntilStart"] <= 5:
         return "#ff5000"
     elif event["detail"]["minutesUntilStart"] <= 2:
         return "#9000ff"
@@ -50,6 +53,8 @@ def get_calendar_text_color(event):
         return DEFAULT
 
 def should_animate_text(event):
+    if event["detail"]["isAllDay"]:
+        return False
     return event["detail"]["minutesUntilStart"] <= 5
 
 def get_tomorrow_text_copy(eventStart, show_full_names):
@@ -61,42 +66,67 @@ def get_tomorrow_text_copy(eventStart, show_full_names):
 
 def get_this_week_text_copy(eventStart, show_full_names):
     DEFAULT = eventStart.format("Mon at 3:04 PM")
+ 
     if show_full_names:
         return eventStart.format("Monday at 3:04 PM")
     else:
         return DEFAULT
 
-def get_expanded_time_text_copy(event, now, eventStart, show_full_names):
+def get_expanded_time_text_copy(event, now, eventStart, eventEnd, show_full_names):
     DEFAULT = "in %s" % humanize.relative_time(now, eventStart)
-    if event["detail"]["isTomorrow"]:
+
+    multiday = False
+    # check if it's a multi-day event
+    if event["detail"]["isAllDay"] and eventStart.day != eventEnd.day:
+        multiday = True
+  
+
+    if event["detail"]["isAllDay"]:
+        # if it's in progress, show the day it ends
+        if event["detail"]["inProgress"] and multiday:
+            return eventEnd.format("until Mon") # + " " + humanize.ordinal(eventEnd.day)
+        # if the event is all day and ends today, show nothing
+        elif event["detail"]["inProgress"]:
+            return eventEnd.format("")
+        # if the event is all day but not started, just show the day it starts
+        else:
+            return eventStart.format("on Mon")
+    elif event["detail"]["isTomorrow"]:
         return get_tomorrow_text_copy(eventStart , show_full_names)
+
     elif event["detail"]["isThisWeek"]:
         return get_this_week_text_copy(eventStart, show_full_names)
     else:
         return DEFAULT
 
-def get_calendar_text_copy(event, now, eventStart, show_expanded_time_window, show_full_names):
+def get_calendar_text_copy(event, now, eventStart, eventEnd, show_expanded_time_window, show_full_names):
     DEFAULT = eventStart.format("at 3:04 PM")
 
     if not event["detail"]["isToday"] and not show_expanded_time_window:
         return DONE_TEXT
     elif event["detail"] and show_expanded_time_window:
-        return get_expanded_time_text_copy(event, now, eventStart, show_full_names)
-    elif event["detail"] and event["detail"]["minutesUntilStart"] <= 5:
+        return get_expanded_time_text_copy(event, now, eventStart, eventEnd, show_full_names)
+    elif event["detail"] and not event["detail"]["isAllDay"] and event["detail"]["minutesUntilStart"] <= 5:
         return "in %d min" % event["detail"]["minutesUntilStart"]
+    elif event["detail"]["isAllDay"] and not show_expanded_time_window:
+        return get_expanded_time_text_copy(event, now, eventStart, eventEnd, show_full_names)
     else:
         return DEFAULT
 
 def get_calendar_render_data(now, usersTz, event, show_expanded_time_window, show_full_names):
+    
     baseObject = {
         "currentMonth": now.format("Jan").upper(),
         "currentDay": humanize.ordinal(now.day),
         "now": now,
     }
 
+    #if there's no event or it is an all day event, build the top part of calendar as usual
     if not event:
         baseObject["hasEvent"] = False
         return baseObject
+
+
     
     shouldRenderSummary = event["detail"]["isToday"] or show_expanded_time_window
     if not shouldRenderSummary:
@@ -104,14 +134,16 @@ def get_calendar_render_data(now, usersTz, event, show_expanded_time_window, sho
         return baseObject
 
     startTime = time.from_timestamp(int(event["start"])).in_location(usersTz)
+    endTime = time.from_timestamp(int(event["end"])).in_location(usersTz)
     eventObject = {
         "summary": get_event_summary(event["name"]),
         "eventStartTimestamp": startTime,
-        "copy": get_calendar_text_copy(event, now, startTime, show_expanded_time_window, show_full_names),
+        "copy": get_calendar_text_copy(event, now, startTime, endTime, show_expanded_time_window, show_full_names),
         "textColor": get_calendar_text_color(event),
         "shouldAnimateText": should_animate_text(event),
         "hasEvent": True,
         "isToday": event["detail"]["isToday"],
+        "isAllDay": event["detail"]["isAllDay"],
     }
 
     return dict(baseObject.items() + eventObject.items())
@@ -203,6 +235,9 @@ def build_calendar_frame(now, usersTz, event, show_expanded_time_window, show_fu
     # top half displays the calendar icon and date
     top = get_calendar_top(data)
     bottom = get_calendar_bottom(data)
+
+    # if it's an all day event, build the calendar up top and drop the name of the event below
+    #something goes here
 
     # bottom half displays the upcoming event, if there is one.
     # otherwise it just shows the time.

--- a/apps/universalical/universal_ical.star
+++ b/apps/universalical/universal_ical.star
@@ -104,6 +104,8 @@ def get_calendar_text_copy(event, now, eventStart, eventEnd, show_expanded_time_
 
     if not event["detail"]["isToday"] and not show_expanded_time_window:
         return DONE_TEXT
+    elif event["detail"]["isToday"] and not event["detail"]["inProgress"]:
+        return DEFAULT
     elif event["detail"] and show_expanded_time_window:
         return get_expanded_time_text_copy(event, now, eventStart, eventEnd, show_full_names)
     elif event["detail"] and not event["detail"]["isAllDay"] and event["detail"]["minutesUntilStart"] <= 5:

--- a/apps/universalical/universal_ical.star
+++ b/apps/universalical/universal_ical.star
@@ -103,7 +103,6 @@ def get_calendar_render_data(now, usersTz, event, show_expanded_time_window):
     shouldRenderSummary = event["detail"]["isToday"] or show_expanded_time_window
     if not shouldRenderSummary:
         baseObject["hasEvent"] = False
-        print("we're doing it.")
         return baseObject
 
     startTime = time.from_timestamp(int(event["start"])).in_location(usersTz)


### PR DESCRIPTION
A few bug fixes for Universal iCal:

- two of the options were not supported -- show expanded time window and show shortened names were default coded
- some logic was missing on timezone calculations for events happening today

Some enhancements:

- All Day events now have their own logic to display only the date and not the time
- Future All day events supported gracefully
- Multi-day all day events now have logic to show when they end